### PR TITLE
Fix Sidebar Navigation Arrow

### DIFF
--- a/features/layout/sidebar-navigation/menu-item-button.tsx
+++ b/features/layout/sidebar-navigation/menu-item-button.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { Button } from "@features/ui";
+import React from "react";
 import classNames from "classnames";
 import styles from "./menu-item-link.module.scss";
 
@@ -22,7 +22,15 @@ export function MenuItemButton({
     <li className={classNames(styles.listItem, className)}>
       <Button className={styles.anchor} onClick={onClick}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img className={styles.icon} src={iconSrc} alt={`${text} icon`} />{" "}
+        <img
+          className={
+            isCollapsed && iconSrc === "/icons/arrow-left.svg"
+              ? styles.iconTransformed
+              : styles.icon
+          }
+          src={iconSrc}
+          alt={`${text} icon`}
+        />{" "}
         {!isCollapsed && text}{" "}
       </Button>
     </li>

--- a/features/layout/sidebar-navigation/menu-item-link.module.scss
+++ b/features/layout/sidebar-navigation/menu-item-link.module.scss
@@ -26,7 +26,12 @@
   text-decoration: none;
 }
 
-.icon {
+.icon,
+.iconTransformed {
   width: space.$s6;
   margin-right: space.$s3;
+}
+
+.iconTransformed {
+  transform: rotate(180deg);
 }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -1,12 +1,13 @@
-import { useRouter } from "next/router";
 import { useContext, useState } from "react";
-import { Routes } from "@config/routes";
-import classNames from "classnames";
-import { NavigationContext } from "./navigation-context";
+
+import { Button } from "@features/ui";
 import { MenuItemButton } from "./menu-item-button";
 import { MenuItemLink } from "./menu-item-link";
-import { Button } from "@features/ui";
+import { NavigationContext } from "./navigation-context";
+import { Routes } from "@config/routes";
+import classNames from "classnames";
 import styles from "./sidebar-navigation.module.scss";
+import { useRouter } from "next/router";
 
 const menuItems = [
   { text: "Projects", iconSrc: "/icons/projects.svg", href: Routes.projects },


### PR DESCRIPTION
This PR attempts to resolve the issue where the sidebar arrow was not rotating once the sidebar was closed.

To test: Spin up the app in the `fix-sidebar-navigation-arrow `branch and test the sidebar behavior. 