### PR TITLE
Fix Project Card Divider Thickness

### DIFF
--- a/features/projects/components/project-card/project-card.module.scss
+++ b/features/projects/components/project-card/project-card.module.scss
@@ -19,7 +19,7 @@
 
 .bottomContainer {
   padding: space.$s4 space.$s6;
-  border-top: 3px solid color.$gray-200;
+  border-top: 1px solid color.$gray-200;
   display: flex;
   justify-content: flex-end;
 }


### PR DESCRIPTION
This PR attempts to resolve the issue with the separator line being too thick compared to the [Figma](https://www.figma.com/file/8ZmbMRC8PtvXx7L5PjVcVM/Prolog?type=design&node-id=156-21829&mode=design&t=i5Atj8N15iA2ajyu-0) design. 

To test: Spin up the app in the fix-project-card-divider-thickness branch and compare the project card to the[ Figma](https://www.figma.com/file/8ZmbMRC8PtvXx7L5PjVcVM/Prolog?type=design&node-id=156-21829&mode=design&t=i5Atj8N15iA2ajyu-0) design. 