### PR TITLE
Fix Issue List Pagination Color

### DIFF
--- a/features/issues/components/issue-list/issue-list.module.scss
+++ b/features/issues/components/issue-list/issue-list.module.scss
@@ -51,7 +51,7 @@
 }
 
 .pageInfo {
-  color: color.$gray-300;
+  color: color.$gray-700;
   font: font.$text-sm-regular;
 }
 


### PR DESCRIPTION
This PR attempts to fix the incorrect color on the page numbers on the issues list. 

To test: Spin up the app in the`fix-issue-list-pagination-color` branch and compare the page numbers on the issue list with the [Figma](https://www.figma.com/file/8ZmbMRC8PtvXx7L5PjVcVM/Prolog?type=design&node-id=1-15362&mode=design&t=i5Atj8N15iA2ajyu-0) design. 