### PR TITLE
Fix Navigation Logo When Switching To Mobile

### DIFF
--- a/features/layout/sidebar-navigation/navigation-context.tsx
+++ b/features/layout/sidebar-navigation/navigation-context.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 type NavigationContextProviderProps = {
   children: React.ReactNode;
@@ -18,6 +18,16 @@ export function NavigationProvider({
   const [isSidebarCollapsed, setSidebarCollapsed] = useState(
     defaultContext.isSidebarCollapsed,
   );
+
+  useEffect(() => {
+    const detectWindowSize = () => {
+      if (window.innerWidth < 1024) setSidebarCollapsed(false);
+    };
+    window.addEventListener("resize", detectWindowSize);
+    return () => {
+      window.removeEventListener("resize", detectWindowSize);
+    };
+  }, []);
 
   return (
     <NavigationContext.Provider


### PR DESCRIPTION
This PR resolves the issue referenced in [this ticket](https://profy.dev/project/react-job-simulator/board). When a user would switch device orientation in a way that resulted in a change from desktop to mobile, the wrong Profy logo was loading.

To test: Spin up the app in a tablet viewport (e.g. iPad in the Chrome Dev Tools), switch on landscape, collapse the sidebar navigation, and rotate the screen to portrait mode. Previously, this would result in the Profy logo being too large for the header.  The issue should now be resolved. 