### PR TITLE
Fix Issue List Number Of Events

### DIFF
--- a/api/issues.types.ts
+++ b/api/issues.types.ts
@@ -12,4 +12,5 @@ export type Issue = {
   stack: string;
   level: IssueLevel;
   numEvents: number;
+  numUsers: number;
 };

--- a/cypress/e2e/issue-list.cy.ts
+++ b/cypress/e2e/issue-list.cy.ts
@@ -45,6 +45,7 @@ describe("Issue List", () => {
           cy.wrap($el).contains(issue.name);
           cy.wrap($el).contains(issue.message);
           cy.wrap($el).contains(issue.numEvents);
+          cy.wrap($el).contains(issue.numUsers);
           cy.wrap($el).contains(firstLineOfStackTrace);
         });
     });

--- a/features/issues/components/issue-list/issue-row.tsx
+++ b/features/issues/components/issue-list/issue-row.tsx
@@ -1,8 +1,9 @@
-import capitalize from "lodash/capitalize";
 import { Badge, BadgeColor, BadgeSize } from "@features/ui";
-import { ProjectLanguage } from "@api/projects.types";
-import { IssueLevel } from "@api/issues.types";
+
 import type { Issue } from "@api/issues.types";
+import { IssueLevel } from "@api/issues.types";
+import { ProjectLanguage } from "@api/projects.types";
+import capitalize from "lodash/capitalize";
 import styles from "./issue-row.module.scss";
 
 type IssueRowProps = {
@@ -17,7 +18,7 @@ const levelColors = {
 };
 
 export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
-  const { name, message, stack, level, numEvents } = issue;
+  const { name, message, stack, level, numEvents, numUsers } = issue;
   const firstLineOfStackTrace = stack.split("\n")[1];
 
   return (
@@ -43,7 +44,7 @@ export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
         </Badge>
       </td>
       <td className={styles.cell}>{numEvents}</td>
-      <td className={styles.cell}>{numEvents}</td>
+      <td className={styles.cell}>{numUsers}</td>
     </tr>
   );
 }


### PR DESCRIPTION
This PR corrects the issue addressed in [this ticket](https://profy.dev/project/react-job-simulator/board). The issues list was returning inaccurate data for the number of users. Rather than returning the number of users, the data that was displayed was the number of events. 

To test: Spin up the app and visit the[ issues page](http://localhost:3000/dashboard/issues). Rather than seeing the events total in both columns, the number of users should now be reflected in the users' column. A Cypress test was also written that should be run when reviewing this PR. 